### PR TITLE
Add ErrorCause to AuthResult.ERROR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -159,7 +159,7 @@ Following values can be returned by prepareCall:
 ```kotlin
 when(authenticator.prepareCall()) {
     AuthResult.CANCELLED_FLOW -> TODO() // return status so domain layer can decide what to do
-    AuthResult.ERROR -> TODO() // // return status so domain layer can decide what to do
+    is AuthResult.ERROR -> TODO() // // return status so domain layer can decide what to do
     AuthResult.SUCCESS -> TODO() // perform network call and return data or error
 }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
-# TicketAuth Android 1.1.4
+# TicketAuth Android 1.2.0
 
 Small android library that simplifies OAuth Code flow (web logins).
-This describes release 1.1.4, for earlier versions of the documentation, consult the relevant release branches.
+This describes release 1.2.0, for earlier versions of the documentation, consult the relevant release branches.
 
 # Usage
 
@@ -191,7 +191,7 @@ TicketAuth.authenticator().login { result ->
         AuthResult.CANCELLED_FLOW -> {
             // do something
         }
-        AuthResult.ERROR -> {
+        is AuthResult.ERROR -> {
             // do something
         }
     }
@@ -221,7 +221,7 @@ TicketAuth.authenticator().logout { result ->
         AuthResult.CANCELLED_FLOW -> {
             // do something
         }
-        AuthResult.ERROR -> {
+        is AuthResult.ERROR -> {
             // do something
         }
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,7 +145,7 @@ This is used for communicating with the library.
 
 ### Prepare network code
 For TicketAuth to do its thing, you need to call a method (prepareCall) before issuing
-your network calls. If it returns AuthResult.ERROR it means that the library failed in obtaining
+your network calls. If it returns AuthResult.Error it means that the library failed in obtaining
 a valid access token. 
 
 #### Return values
@@ -153,14 +153,14 @@ a valid access token.
 Following values can be returned by prepareCall:
 
 - AuthResult.SUCCESS, we got a token, all good
-- AuthResult.CANCELLED_FLOW, user cancelled the login flow (by closing the browser window)
-- AuthResult.ERROR, Something went wrong, likely network error.
+- AuthResult.CancelledFlow, user cancelled the login flow (by closing the browser window)
+- AuthResult.Error, Something went wrong, likely network error.
 
 ```kotlin
 when(authenticator.prepareCall()) {
-    AuthResult.CANCELLED_FLOW -> TODO() // return status so domain layer can decide what to do
-    is AuthResult.ERROR -> TODO() // // return status so domain layer can decide what to do
-    AuthResult.SUCCESS -> TODO() // perform network call and return data or error
+    AuthResult.CancelledFlow -> TODO() // return status so domain layer can decide what to do
+    is AuthResult.Error -> TODO() // // return status so domain layer can decide what to do
+    AuthResult.Success -> TODO() // perform network call and return data or error
 }
 ```
 
@@ -185,13 +185,13 @@ etc.
 ```kotlin
 TicketAuth.authenticator().login { result ->
     when(result) {
-        AuthResult.SUCCESS -> {
+        AuthResult.Success -> {
             // do something
         }
-        AuthResult.CANCELLED_FLOW -> {
+        AuthResult.CancelledFlow -> {
             // do something
         }
-        is AuthResult.ERROR -> {
+        is AuthResult.Error -> {
             // do something
         }
     }
@@ -215,13 +215,13 @@ It is possible to get called back whenever the logout flow is completed.
 ```kotlin
 TicketAuth.authenticator().logout { result ->
     when(result) {
-        AuthResult.SUCCESS -> {
+        AuthResult.Success -> {
             // do something
         }
-        AuthResult.CANCELLED_FLOW -> {
+        AuthResult.CancelledFlow -> {
             // do something
         }
-        is AuthResult.ERROR -> {
+        is AuthResult.Error -> {
             // do something
         }
     }

--- a/ticketauth/build.gradle.kts
+++ b/ticketauth/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         buildConfigField(
             "String",
             "TICKETAUTH_VERSION",
-            "\"1.1.4\""
+            "\"1.2.0\""
         )
     }
 

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthResult.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthResult.kt
@@ -1,7 +1,21 @@
 package dk.ufst.ticketauth
 
-enum class AuthResult {
-    SUCCESS,
-    CANCELLED_FLOW,
-    ERROR
+import androidx.activity.result.ActivityResult
+import dk.ufst.ticketauth.authcode.AuthorizationError
+import dk.ufst.ticketauth.authcode.RedirectUriParser
+
+sealed interface AuthResult {
+    object SUCCESS : AuthResult
+    object CANCELLED_FLOW : AuthResult
+    data class ERROR(val reason: ErrorCause) : AuthResult
+}
+
+sealed interface ErrorCause {
+    data class GetToken(val throwable: Throwable) : ErrorCause
+    data class AuthorizationFlow(val authorizationError: AuthorizationError) : ErrorCause
+    data class ParseRedirectUri(val redirectUriParserError: RedirectUriParser.ParsedResult.Error) : ErrorCause
+    data class UnknownAuthIntentResult(val activityResult: ActivityResult) : ErrorCause
+    object MissingIdToken : ErrorCause
+    data class UnknownRedirectUri(val expectedRedirectUri: String, val actualRedirectUri: String) : ErrorCause
+    data class LaunchIntent(val throwable: Throwable) : ErrorCause
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthResult.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthResult.kt
@@ -5,9 +5,9 @@ import dk.ufst.ticketauth.authcode.AuthorizationError
 import dk.ufst.ticketauth.authcode.RedirectUriParser
 
 sealed interface AuthResult {
-    object SUCCESS : AuthResult
-    object CANCELLED_FLOW : AuthResult
-    data class ERROR(val reason: ErrorCause) : AuthResult
+    object Success : AuthResult
+    object CancelledFlow : AuthResult
+    data class Error(val reason: ErrorCause) : AuthResult
 }
 
 sealed interface ErrorCause {

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/AuthCodeEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/AuthCodeEngine.kt
@@ -116,10 +116,10 @@ internal class AuthCodeEngine(
                 val error = AuthorizationError.fromIntent(result.data!!)
                 if(error.error == BrowserManagementActivity.USER_CANCEL) {
                     log("User cancelled authorization flow")
-                    wakeThreads(AuthResult.CANCELLED_FLOW, isLogin = true)
+                    wakeThreads(AuthResult.CancelledFlow, isLogin = true)
                 } else {
                     log("Received error authorization flow: $error")
-                    wakeThreads(AuthResult.ERROR(ErrorCause.AuthorizationFlow(error)), isLogin = true)
+                    wakeThreads(AuthResult.Error(ErrorCause.AuthorizationFlow(error)), isLogin = true)
                 }
                 return
             }
@@ -131,7 +131,7 @@ internal class AuthCodeEngine(
                     log("responseUri parsed result: $parsedResult")
                     when(parsedResult) {
                         is RedirectUriParser.ParsedResult.Error -> {
-                            wakeThreads(AuthResult.ERROR(ErrorCause.ParseRedirectUri(parsedResult)), isLogin = true)
+                            wakeThreads(AuthResult.Error(ErrorCause.ParseRedirectUri(parsedResult)), isLogin = true)
                         }
                         is RedirectUriParser.ParsedResult.Success -> exchangeCodeForToken(parsedResult)
                     }
@@ -139,7 +139,7 @@ internal class AuthCodeEngine(
                 return
             }
         }
-        wakeThreads(AuthResult.ERROR(ErrorCause.UnknownAuthIntentResult(result)), isLogin = true)
+        wakeThreads(AuthResult.Error(ErrorCause.UnknownAuthIntentResult(result)), isLogin = true)
     }
 
     private fun exchangeCodeForToken(result: RedirectUriParser.ParsedResult.Success) {
@@ -156,11 +156,11 @@ internal class AuthCodeEngine(
             log("Sending authorization request:\n${params}")
             val jsonResponse = MicroHttp.postFormUrlEncoded("${dcsBaseUrl}${TOKEN_PATH}", params)
             processTokenResponse(jsonResponse)
-            wakeThreads(AuthResult.SUCCESS, isLogin = true)
+            wakeThreads(AuthResult.Success, isLogin = true)
         } catch (t : Throwable) {
             log("Token endpoint called failed with exception: ${t.message}")
             t.printStackTrace()
-            wakeThreads(AuthResult.ERROR(ErrorCause.GetToken(throwable = t)), isLogin = true)
+            wakeThreads(AuthResult.Error(ErrorCause.GetToken(throwable = t)), isLogin = true)
         }
     }
 
@@ -223,7 +223,7 @@ internal class AuthCodeEngine(
     override fun launchLogoutIntent() {
         if(authState == null) {
             log("Cannot call logout endpoint with no id token")
-            wakeThreads(AuthResult.ERROR(ErrorCause.MissingIdToken), isLogin = false)
+            wakeThreads(AuthResult.Error(ErrorCause.MissingIdToken), isLogin = false)
             return
         }
         val logoutUri = Uri.parse("${dcsBaseUrl}${LOGOUT_PATH}").buildUpon()
@@ -248,10 +248,10 @@ internal class AuthCodeEngine(
                 val error = AuthorizationError.fromIntent(result.data!!)
                 if(error.error == BrowserManagementActivity.USER_CANCEL) {
                     log("User cancelled authorization flow")
-                    wakeThreads(AuthResult.CANCELLED_FLOW, isLogin = false)
+                    wakeThreads(AuthResult.CancelledFlow, isLogin = false)
                 } else {
                     log("Received error authorization flow: $error")
-                    wakeThreads(AuthResult.ERROR(ErrorCause.AuthorizationFlow(error)), isLogin = false)
+                    wakeThreads(AuthResult.Error(ErrorCause.AuthorizationFlow(error)), isLogin = false)
                 }
                 return
             }
@@ -261,11 +261,11 @@ internal class AuthCodeEngine(
                 if(responseUri.toString().startsWith(redirectUri)) {
                     clear()
                     roles.clear()
-                    wakeThreads(AuthResult.SUCCESS, isLogin = false)
+                    wakeThreads(AuthResult.Success, isLogin = false)
                 } else {
                     log("wrong uri, expected: $redirectUri")
                     wakeThreads(
-                        AuthResult.ERROR(ErrorCause.UnknownRedirectUri(
+                        AuthResult.Error(ErrorCause.UnknownRedirectUri(
                             expectedRedirectUri = redirectUri,
                             actualRedirectUri = responseUri.toString(),
                         )), isLogin = false
@@ -274,7 +274,7 @@ internal class AuthCodeEngine(
                 return
             }
         }
-        wakeThreads(AuthResult.ERROR(ErrorCause.UnknownAuthIntentResult(result)), isLogin = false)
+        wakeThreads(AuthResult.Error(ErrorCause.UnknownAuthIntentResult(result)), isLogin = false)
     }
 
     override fun needsTokenRefresh(): Boolean {

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/automated/AutomatedAuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/automated/AutomatedAuthEngine.kt
@@ -89,7 +89,7 @@ internal class AutomatedAuthEngine(
             }
         } catch (t : Throwable) {
             log("Cannot launch select user activity due to exception: ${t.message}")
-            wakeThreads(AuthResult.ERROR(ErrorCause.LaunchIntent(t)))
+            wakeThreads(AuthResult.Error(ErrorCause.LaunchIntent(t)))
         }
     }
 
@@ -98,14 +98,14 @@ internal class AutomatedAuthEngine(
         authState = null
         persistAuthState()
         roles.clear()
-        wakeThreads(AuthResult.SUCCESS)
+        wakeThreads(AuthResult.Success)
     }
 
     private fun processSelectUserResult(result: ActivityResult) {
         log("processAuthResult $result")
         if(result.resultCode == Activity.RESULT_CANCELED) {
             log("Select user activity was cancelled by user")
-            wakeThreads(AuthResult.CANCELLED_FLOW)
+            wakeThreads(AuthResult.CancelledFlow)
         } else {
             result.data?.let { data ->
                 val index = data.getIntExtra("index", -1)
@@ -113,7 +113,7 @@ internal class AutomatedAuthEngine(
                 loginUser(users[index])
             } ?: run {
                 log("ActivityResult yielded no data (intent) to process")
-                wakeThreads(AuthResult.ERROR(ErrorCause.UnknownAuthIntentResult(result)))
+                wakeThreads(AuthResult.Error(ErrorCause.UnknownAuthIntentResult(result)))
             }
         }
     }
@@ -144,7 +144,7 @@ internal class AutomatedAuthEngine(
                 processTokenResponse(jsonResponse)
             } catch (t : Throwable) {
                 log("Token endpoint called failed with exception: ${t.message}")
-                wakeThreads(AuthResult.ERROR(ErrorCause.GetToken(t)))
+                wakeThreads(AuthResult.Error(ErrorCause.GetToken(t)))
             }
         }
     }
@@ -155,7 +155,7 @@ internal class AutomatedAuthEngine(
         log("Token expiration: ${authState?.tokenExpTime}")
         persistAuthState()
         onAccessToken()
-        wakeThreads(AuthResult.SUCCESS)
+        wakeThreads(AuthResult.Success)
     }
 
     private fun wakeThreads(result: AuthResult) {

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/automated/AutomatedAuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/automated/AutomatedAuthEngine.kt
@@ -11,6 +11,7 @@ import androidx.activity.result.ActivityResult
 import dk.ufst.ticketauth.ActivityLauncher
 import dk.ufst.ticketauth.AuthEngine
 import dk.ufst.ticketauth.AuthResult
+import dk.ufst.ticketauth.ErrorCause
 import dk.ufst.ticketauth.OnAuthResultCallback
 import dk.ufst.ticketauth.OnNewAccessTokenCallback
 import dk.ufst.ticketauth.shared.AuthJob
@@ -88,7 +89,7 @@ internal class AutomatedAuthEngine(
             }
         } catch (t : Throwable) {
             log("Cannot launch select user activity due to exception: ${t.message}")
-            wakeThreads(AuthResult.ERROR)
+            wakeThreads(AuthResult.ERROR(ErrorCause.LaunchIntent(t)))
         }
     }
 
@@ -112,7 +113,7 @@ internal class AutomatedAuthEngine(
                 loginUser(users[index])
             } ?: run {
                 log("ActivityResult yielded no data (intent) to process")
-                wakeThreads(AuthResult.ERROR)
+                wakeThreads(AuthResult.ERROR(ErrorCause.UnknownAuthIntentResult(result)))
             }
         }
     }
@@ -143,7 +144,7 @@ internal class AutomatedAuthEngine(
                 processTokenResponse(jsonResponse)
             } catch (t : Throwable) {
                 log("Token endpoint called failed with exception: ${t.message}")
-                wakeThreads(AuthResult.ERROR)
+                wakeThreads(AuthResult.ERROR(ErrorCause.GetToken(t)))
             }
         }
     }
@@ -272,4 +273,3 @@ internal class AutomatedAuthEngine(
         }
     }
 }
-

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/shared/AuthenticatorImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/shared/AuthenticatorImpl.kt
@@ -48,7 +48,7 @@ internal class AuthenticatorImpl(
 
     override fun prepareCall(): AuthResult {
         val job = spawnJob(noReturn = false)
-        var result = AuthResult.SUCCESS
+        var result: AuthResult = AuthResult.SUCCESS
         if(engine.needsTokenRefresh()) {
             log("Token needs refresh, pausing network call")
             // first caller creates the latch and waits, subsequent callers just wait on the latch
@@ -69,7 +69,7 @@ internal class AuthenticatorImpl(
             latch.get()?.await()
 
             job.result?.let {
-                log("Thread woke up but found pending AuthResult: ${it.name}, return result")
+                log("Thread woke up but found pending AuthResult: ${it}, return result")
                 result = it
             }
         }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/shared/AuthenticatorImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/shared/AuthenticatorImpl.kt
@@ -48,7 +48,7 @@ internal class AuthenticatorImpl(
 
     override fun prepareCall(): AuthResult {
         val job = spawnJob(noReturn = false)
-        var result: AuthResult = AuthResult.SUCCESS
+        var result: AuthResult = AuthResult.Success
         if(engine.needsTokenRefresh()) {
             log("Token needs refresh, pausing network call")
             // first caller creates the latch and waits, subsequent callers just wait on the latch


### PR DESCRIPTION
Add `ErrorCause` to `AuthResult.ERROR` so the `ErrorCause` can be logged when experiencing login/logout errors.
This extra detailed information can be beneficial when debugging login/logout errors.

To add `ErrorCause` I have changed `AuthResult` to a `sealed interface` for `AuthResult.ERROR` could contain an `ErrorCause`. This results in you have to use `is` to check for `AuthResult.ERROR` type. 

